### PR TITLE
Fix bogus bibliography heading with biblatex (#77)

### DIFF
--- a/ppt-slides.dtx
+++ b/ppt-slides.dtx
@@ -508,6 +508,21 @@
 %    \end{macrocode}
 % \end{macro}
 
+% \changes{0.8.0}{2026/06/11}{A \texttt{biblatex}-compatible bibliography heading defined.}
+% Then, when \href{https://ctan.org/pkg/biblatex}{biblatex} is loaded, we declare
+% a bibliography heading that uses |\pptBanner| instead of |\section*|. The
+% |crumbs| package redefines |\section| in a way that does not understand its
+% starred form, so |biblatex|'s default heading (which issues |\section*{\refname}|)
+% would otherwise render as a bogus numbered section. This also makes the references
+% slide visually consistent with other |\pptBanner| headings:
+%    \begin{macrocode}
+\AtBeginDocument{%
+  \ifdefined\printbibliography%
+    \defbibheading{bibliography}[\refname]{\pptBanner{#1}}%
+  \fi%
+}
+%    \end{macrocode}
+
 % \begin{macro}{\pptChapter}
 % \changes{0.4.0}{2024/10/18}{The \texttt{\char`\\pptChapterLabel} command introduced.}
 % Then, we define the |\pptChapter| and |\pptChapterLabel| commands:


### PR DESCRIPTION
Fixes #77.

## Problem

When a deck uses `biblatex` and calls `\printbibliography`, the bibliography heading came out as a numbered section titled "1 *", with "References" typeset below as plain text, plus a stray "*" crumb in the upper-left corner.

The cause is the `crumbs` package (loaded unconditionally), which redefines `\section` without understanding the starred form. `biblatex`'s default heading issues `\section*{\refname}`, so the `*` token gets consumed as the mandatory title argument.

## Fix

When `biblatex` is loaded, declare a `biblatex`-compatible bibliography heading that routes through `\pptBanner` instead of `\section*`:

```latex
\AtBeginDocument{%
  \ifdefined\printbibliography%
    \defbibheading{bibliography}[\refname]{\pptBanner{#1}}%
  \fi%
}
```

This avoids the redefined `\section` entirely and makes the references slide visually consistent with other `\pptBanner` headings.

Note: as the issue mentions, the star-unaware `\section` redefinition itself arguably deserves a separate fix in `yegor256/crumbs`.

https://claude.ai/code/session_01EdaqsBinTqpxyG3sYCjqVz

---
_Generated by [Claude Code](https://claude.ai/code/session_01EdaqsBinTqpxyG3sYCjqVz)_